### PR TITLE
Add dark-themed single page site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pistote Initiative Studio</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&family=Orbitron:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="navbar">
+  <div class="logo">Pistote Initiative Studio</div>
+  <nav id="nav-links" class="nav-links">
+    <a href="#about">About</a>
+    <a href="#projects">Projects</a>
+    <a href="#contact">Contact</a>
+  </nav>
+  <div id="nav-toggle" class="nav-toggle">
+    <span></span><span></span><span></span>
+  </div>
+</header>
+
+<section id="hero" class="hero">
+  <div class="hero-content fade-in">
+    <h1>Pistote Initiative Studio</h1>
+    <p class="subtitle">Practical software for real-world operations</p>
+    <a href="#projects" class="btn">See Our Work</a>
+  </div>
+</section>
+
+<section id="about" class="section">
+  <h2>About Pistote</h2>
+  <p>We’re a lean, independent software studio focused on building purposeful apps that streamline complex workflows. Our mission is to craft tools that quietly do their job — saving time, reducing friction, and empowering people in the field.</p>
+</section>
+
+<section id="projects" class="section">
+  <h2>Our Projects</h2>
+  <div class="projects-grid">
+    <div class="card">
+      <h3>Plane Load Planner</h3>
+      <p>A mobile app designed to simplify aircraft cargo loading for ramp agents. Built to optimize workflows, reduce errors, and support fast-paced air operations.</p>
+    </div>
+    <div class="card">
+      <h3>Office Inventory Tracker (In Development)</h3>
+      <p>Track and manage office supplies with ease. Ideal for startups, studios, and shared workspaces. Currently in development — stay tuned.</p>
+    </div>
+  </div>
+</section>
+
+<section id="contact" class="section">
+  <h2>Let’s Connect</h2>
+  <p><a href="mailto:peterjubitz@pistotestudio.com">peterjubitz@pistotestudio.com</a></p>
+</section>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('nav-toggle');
+  const navLinks = document.getElementById('nav-links');
+
+  toggle.addEventListener('click', () => {
+    navLinks.classList.toggle('open');
+  });
+
+  const options = { threshold: 0.1 };
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if(entry.isIntersecting) {
+        entry.target.classList.add('visible');
+      }
+    });
+  }, options);
+
+  document.querySelectorAll('.section').forEach(sec => {
+    sec.classList.add('fade-in');
+    observer.observe(sec);
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,172 @@
+:root {
+  --bg-color: #0e0f19;
+  --accent-color: #00bfff;
+  --text-color: #f5f5f5;
+  --nav-bg: rgba(0,0,0,0.8);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+.navbar {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background: var(--nav-bg);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+}
+
+.logo {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 600;
+  color: ivory;
+}
+
+.nav-links a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: var(--text-color);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  height: 3px;
+  width: 25px;
+  background: var(--text-color);
+  margin: 4px 0;
+  transition: 0.4s;
+}
+
+.hero {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #030308 0%, #0d1141 100%);
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle at center, transparent 30%, rgba(0, 191, 255, 0.1) 31%);
+  animation: rotate 20s linear infinite;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  animation: fadeIn 1s ease-in;
+}
+
+.hero h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 3rem;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 1rem 0;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1.5rem;
+  background: var(--accent-color);
+  color: #000;
+  text-decoration: none;
+  border-radius: 3px;
+}
+
+.section {
+  padding: 4rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(255,255,255,0.05);
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.5);
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 0 15px rgba(0, 191, 255, 0.5);
+}
+
+@keyframes rotate {
+  from {transform: rotate(0deg);}
+  to {transform: rotate(360deg);}
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .projects-grid {
+    grid-template-columns: 1fr;
+  }
+  .nav-links {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--nav-bg);
+    flex-direction: column;
+    width: 200px;
+    display: none;
+  }
+  .nav-links a {
+    margin: 1rem;
+  }
+  .nav-toggle {
+    display: flex;
+  }
+  .nav-links.open {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary
- build dark-themed responsive website for Pistote Initiative Studio
- implement sticky navigation, hero, about, projects and contact sections
- style with cyberpunk-inspired gradients and animations
- add mobile menu and section scroll animations

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68806016fce8833187022d0a09efcd97