### PR TITLE
Update hero design

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 
 <section id="hero" class="hero">
   <div class="hero-content fade-in">
-    <h1>Pistote Initiative Studio</h1>
+    <h1><span class="main-title">Pistote Initiative</span><span class="studio">Studio</span></h1>
     <p class="subtitle">Practical software for real-world operations</p>
     <a href="#projects" class="btn">See Our Work</a>
   </div>

--- a/style.css
+++ b/style.css
@@ -62,7 +62,7 @@ body {
   text-align: center;
   position: relative;
   overflow: hidden;
-  background: linear-gradient(135deg, #030308 0%, #0d1141 100%);
+  background: linear-gradient(160deg, #000000 0%, #020d26 100%);
 }
 
 .hero::before {
@@ -72,8 +72,15 @@ body {
   left: -50%;
   width: 200%;
   height: 200%;
-  background: radial-gradient(circle at center, transparent 30%, rgba(0, 191, 255, 0.1) 31%);
-  animation: rotate 20s linear infinite;
+  background:
+    radial-gradient(circle at center, rgba(0,191,255,0.2), transparent 70%),
+    repeating-linear-gradient(135deg,
+      rgba(0,191,255,0.1) 0px,
+      rgba(0,191,255,0.1) 2px,
+      transparent 2px,
+      transparent 20px);
+  animation: rotate 30s linear infinite;
+  pointer-events: none;
 }
 
 .hero-content {
@@ -84,8 +91,17 @@ body {
 
 .hero h1 {
   font-family: 'Orbitron', sans-serif;
-  font-size: 3rem;
   margin: 0;
+}
+
+.hero .main-title {
+  font-size: clamp(3rem, 8vw, 6rem);
+  display: block;
+}
+
+.hero .studio {
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  display: block;
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- enlarge the "Pistote Initiative" portion of the hero title and put "Studio" on its own line
- give the hero a darker cyberpunk background with neon blue accents
- tweak heading styles for responsive sizing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68806890073483318f5cbfc2884553be