### PR TITLE
Implement scroll-triggered hero fade-out

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,4 +19,17 @@ document.addEventListener('DOMContentLoaded', () => {
     sec.classList.add('fade-in');
     observer.observe(sec);
   });
+
+  const hero = document.getElementById('hero');
+  const heroHeight = hero.offsetHeight;
+
+  function handleHeroScroll() {
+    const rect = hero.getBoundingClientRect();
+    const progress = Math.min(Math.max(-rect.top / heroHeight, 0), 1);
+    hero.style.opacity = 1 - progress;
+    hero.style.transform = `translateY(-${progress * heroHeight * 0.5}px)`;
+  }
+
+  window.addEventListener('scroll', handleHeroScroll);
+  handleHeroScroll();
 });

--- a/style.css
+++ b/style.css
@@ -63,6 +63,8 @@ body {
   position: relative;
   overflow: hidden;
   background: linear-gradient(160deg, #000000 0%, #020d26 100%);
+  will-change: opacity, transform;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 
 .hero::before {


### PR DESCRIPTION
## Summary
- add smooth opacity and transform update to hero section on scroll
- enable transitions and will-change hints for hero for smoother animations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68806f00cd708331a5bf46812c126b97