### PR TITLE
Link hero fade-out to scrolling

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,14 +21,12 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const hero = document.getElementById('hero');
-  const heroHeight = hero.offsetHeight;
-  const fadeDistance = 300; // distance in px over which hero fades out
+  const fadeDistance = 400; // distance in px over which hero fades out
 
   function handleHeroScroll() {
     const scrollY = window.scrollY || window.pageYOffset;
     const progress = Math.min(Math.max(scrollY / fadeDistance, 0), 1);
     hero.style.opacity = 1 - progress;
-    hero.style.transform = `translateY(-${progress * heroHeight * 0.5}px)`;
   }
 
   window.addEventListener('scroll', handleHeroScroll);

--- a/style.css
+++ b/style.css
@@ -63,8 +63,8 @@ body {
   position: relative;
   overflow: hidden;
   background: linear-gradient(160deg, #000000 0%, #020d26 100%);
-  will-change: opacity, transform;
-  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  will-change: opacity;
+  transition: opacity 0.2s ease-out;
 }
 
 .hero::before {


### PR DESCRIPTION
## Summary
- extend fade-out distance for the hero section and remove translation effect
- clean up transitions on the hero container

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688072bd8e5c833189f8129ced3e22d1