### PR TITLE
Add scroll fade effect for hero text

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,5 +30,6 @@
         <h2>Contact</h2>
         <p>Email us at: peterjubitz@pistotestudio.com</p>
     </section>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,29 @@
+(function() {
+  const heroTitle = document.querySelector('.hero h1');
+  const heroSubtitle = document.querySelector('.hero h2');
+
+  function updateHeroOpacity() {
+    const start = 0;
+    const end = 200;
+    const scrollY = window.scrollY;
+    let opacity = 1;
+
+    if (scrollY <= start) {
+      opacity = 1;
+    } else if (scrollY >= end) {
+      opacity = 0;
+    } else {
+      opacity = 1 - (scrollY - start) / (end - start);
+    }
+
+    heroTitle.style.opacity = opacity;
+    heroSubtitle.style.opacity = opacity;
+  }
+
+  window.addEventListener('scroll', () => {
+    requestAnimationFrame(updateHeroOpacity);
+  });
+
+  updateHeroOpacity();
+})();
+

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ h1,
 .hero h2 {
     margin: 0;
     font-family: 'Orbitron', sans-serif;
+    opacity: 1;
 }
 
 section h2 {


### PR DESCRIPTION
## Summary
- fade hero title and subtitle as the page scrolls
- load the new script in the homepage
- ensure hero text starts with full opacity

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68823f293cf083318a07cd11b1bfc265